### PR TITLE
Fix ID Generation Logic to Address Issue #5

### DIFF
--- a/frontend/src/api/cameraPreset.ts
+++ b/frontend/src/api/cameraPreset.ts
@@ -3,8 +3,15 @@ import { cameraPresets } from '../stores/cameraPresets';
 import type { CameraPreset } from '../types/cameraPreset';
 
 export async function addCameraPreset(): Promise<void> {
+    // Find the highest id in the current presets and add 1 to it, as previous apporach could lead to duplicate ids
+    // ? This is not the best way to generate unique ids, but it works for now
+    const existingPresets = get(cameraPresets);
+    const existingIds = existingPresets.map(preset => preset.id);
+    // If there are no presets, start from 1 otherwise add 1 to the highest id
+    const newId = existingIds.length > 0 ? Math.max(...existingIds) + 1 : 1;
+
     const newPreset: CameraPreset = {
-        id: get(cameraPresets).length + 1,
+        id: newId,
         workspace_position: { x: 0, y: 0 },
         camera_settings: {zoom: 0, position: {x: 0,y:0}},
         name: '' 


### PR DESCRIPTION
### Description  
This pull request fixes issue #5 by updating the ID generation logic as follows:  
- If no IDs exist, start from 1.  
- Otherwise, generate a new ID by adding 1 to the highest existing ID.  

While this approach is functional, it is not the most robust method for generating unique IDs and may require further refinement in the future.  
